### PR TITLE
Explicitly install hub

### DIFF
--- a/.github/workflows/add_binaries_to_release.yml
+++ b/.github/workflows/add_binaries_to_release.yml
@@ -25,6 +25,7 @@ jobs:
         with:
           toolchain: stable
       - run: rustup component add rustfmt
+      - run: sudo apt install hub
       - name: Build and upload artifact
         run: ./.github/workflows/build_binaries.sh ${{ matrix.os }} ${{ matrix.platform }} merge-app puller-app pusher-app
         env:


### PR DESCRIPTION
It looks like hub is not installed by default anymore in actions, hopefully this installs it for the script to use. Here's the failed job: https://github.com/bazeltools/rules_minidock_tools/actions/runs/6550506538/job/17789918973

```
+ hub release edit -a merge-app-linux-x86_64 -a merge-app-linux-x86_64.sha256 -m '' 0.0.57
./.github/workflows/build_binaries.sh: line 59: hub: command not found
Error: Process completed with exit code 127.
```