### PR TITLE
Match authorization helpers based on registry

### DIFF
--- a/app/puller_app.rs
+++ b/app/puller_app.rs
@@ -5,7 +5,7 @@ use clap::Parser;
 
 use rules_minidock_tools::container_specs::{ConfigDelta, Manifest};
 
-// cargo run --bin puller-app -- --registry l.gcr.io --repository google/bazel --digest sha256:08434856d8196632b936dd082b8e03bae0b41346299aedf60a0d481ab427a69f
+// cargo run --bin puller-app -- --registry l.gcr.io --repository google/bazel --digest sha256:08434856d8196632b936dd082b8e03bae0b41346299aedf60a0d481ab427a69f --architecture=x86_64
 
 #[derive(Parser, Debug)]
 #[clap(name = "puller app")]
@@ -23,8 +23,12 @@ struct Opt {
     architecture: String,
 
     #[clap(long)]
-    // List of comma separated helpers. with the registry:helper_path
-    //e.g. foo.gcr.io:/path/to/helper,bar.gcr.io:/path/to/helper2
+    // List of comma separated helpers in registry:helper_path format;
+    // requests will attempt to match a helper first based on the "service"
+    // field in the authentication challenge, and then based on the registry
+    // param passed to this tool.
+    // e.g. foo.gcr.io:/path/to/helper,bar.gcr.io:/path/to/helper2
+    // 
     docker_authorization_helpers: Option<String>,
 }
 

--- a/app/pusher_app.rs
+++ b/app/pusher_app.rs
@@ -38,8 +38,12 @@ struct Opt {
     skip_manifest_upload: bool,
 
     #[clap(long)]
-    // List of comma separated helpers. with the registry:helper_path
-    //e.g. foo.gcr.io:/path/to/helper,bar.gcr.io:/path/to/helper2
+    // List of comma separated helpers in registry:helper_path format;
+    // requests will attempt to match a helper first based on the "service"
+    // field in the authentication challenge, and then based on the registry
+    // param passed to this tool.
+    // e.g. foo.gcr.io:/path/to/helper,bar.gcr.io:/path/to/helper2
+    // 
     docker_authorization_helpers: Option<String>,
 }
 

--- a/src/registry/http/http_cli/mod.rs
+++ b/src/registry/http/http_cli/mod.rs
@@ -22,6 +22,7 @@ pub struct HttpCli {
     pub inner_client: Client<hyper_rustls::HttpsConnector<hyper::client::HttpConnector>>,
     pub auth_info: Arc<Mutex<Option<AuthResponse>>>,
     pub docker_authorization_helpers: Arc<Vec<DockerAuthenticationHelper>>,
+    pub registry: String,
 }
 
 impl HttpCli {
@@ -101,6 +102,7 @@ impl HttpCli {
                                 &auth_fail,
                                 &self.inner_client,
                                 self.docker_authorization_helpers.clone(),
+                                self.registry.clone(),
                             )
                             .await?;
                             let mut ai = self.auth_info.lock().await;

--- a/src/registry/http/mod.rs
+++ b/src/registry/http/mod.rs
@@ -128,6 +128,7 @@ impl HttpRegistry {
                 inner_client: http_client,
                 docker_authorization_helpers,
                 auth_info: Default::default(),
+                registry: registry_base.as_ref().to_string(),
             },
         };
 


### PR DESCRIPTION
## Problem

I need to use `rules_minidock` with a registry where the `service` returned in the authentication challenge is not the registry base name, but rather a logical service name "Authentication". The header returned by the registry is like:

> www-authenticate: Bearer realm="https://registry.example.com/auth/token/",service="Authentication"

I want to provide an authentication helper script to respond to this challenge, but it's never picked up by `puller_app`, etc. because the current logic always does matching based on the bearer `service`; so I believe there's an assumption here that `service` will be the registry base name (such as `registry.example.com`) but this is not necessarily true.

## Solution

We maintain the current matching logic, but if no matching authentication helper is found based on `service`, we try to match based on the `registry` parameter sent to `puller_app` or `pusher_app`.