### PR TITLE
Drop auth_info on redirect

### DIFF
--- a/src/registry/http/http_cli/mod.rs
+++ b/src/registry/http/http_cli/mod.rs
@@ -95,6 +95,13 @@ impl HttpCli {
                                     )
                                 })?;
                             }
+                            // We drop existing auth info since this may conflict with auth for the
+                            // redirected destination. In particular, a redirect to blobs in S3 may
+                            // include X-Amz-* query parameters in the URL that cannot be used in
+                            // conjunction with an Authentication header.
+                            let mut ai = self.auth_info.lock().await;
+                            *ai = None;
+                            drop(ai);
                             continue;
                         }
                         RequestFailType::ConnectError(_) => continue,


### PR DESCRIPTION
In particular, this addresses a case where a user-facing registry redirects to blob storage in S3, providing a URL that includes various `X-Amz-*` query parameters. S3 refuses requests that have both Authentication header and authentication query parameters.

I _think_ this is generally safe to do. If the redirect is to a different path under the same registry, then the request to new location would include another authentication challenge and the same authentication helper rules would be applied, restoring auth. If the redirect is to a different domain, then I wouldn't expect the same authentication to be accepted anyway, so dropping auth info seems generally desirable.