### PR TITLE
Fix deprecated GitHub Actions commands and update Ubuntu version

### DIFF
--- a/.github/workflows/add_binaries_to_release.yml
+++ b/.github/workflows/add_binaries_to_release.yml
@@ -10,20 +10,19 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-latest, ubuntu-20.04]
+        os: [macos-latest, ubuntu-latest]
         platform: [x86_64]
         include:
           - os: macos-latest
             platform: x86_64
           - os: macos-latest
             platform: aarch64
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             platform: x86_64
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - uses: actions/checkout@v4
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
       - run: rustup component add rustfmt
       - name: Build and upload artifact
         run: ./.github/workflows/build_binaries.sh ${{ matrix.os }} ${{ matrix.platform }} merge-app puller-app pusher-app

--- a/.github/workflows/dependabot_automerge.yml
+++ b/.github/workflows/dependabot_automerge.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v1
+        uses: dependabot/fetch-metadata@v2
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - name: Enable auto-merge for Dependabot PRs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,19 +14,15 @@ jobs:
           - os: ubuntu-latest
             platform: linux
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
       - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all-features
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
+      - name: Run tests with all features
+        run: cargo test --all-features
+      - name: Run tests
+        run: cargo test

--- a/.github/workflows/test_hub.yml
+++ b/.github/workflows/test_hub.yml
@@ -7,20 +7,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-20.04]
+        os: [macos-latest, ubuntu-latest]
         platform: [x86_64]
         include:
           - os: macos-latest
             platform: x86_64
           - os: macos-latest
             platform: aarch64
-          - os: ubuntu-20.04
+          - os: ubuntu-latest
             platform: x86_64
     permissions: read-all
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install hub for Linux
-      if: matrix.os == 'ubuntu-20.04'
+      if: matrix.os == 'ubuntu-latest'
       run: sudo apt-get update && sudo apt-get install -y hub
     - name: List open pull requests
       run: hub pr list


### PR DESCRIPTION
- Update ubuntu-20.04 to ubuntu-latest in all workflows
- Replace deprecated actions/checkout@v2 with actions/checkout@v4
- Replace deprecated actions-rs/* actions with modern alternatives:
  - actions-rs/toolchain@v1 -> dtolnay/rust-toolchain@stable
  - actions-rs/cargo@v1 -> direct cargo commands
- Update dependabot/fetch-metadata@v1 to @v2
- These changes fix the 'set-output command is deprecated' warnings