### PR TITLE
Retype the manifest envelope in set_specification_type

### DIFF
--- a/src/container_specs/manifest.rs
+++ b/src/container_specs/manifest.rs
@@ -68,11 +68,11 @@ impl Manifest {
     }
 
     pub fn set_specification_type(mut self, specification_type: SpecificationType) -> Manifest {
+        self.specification_type = specification_type;
         self.config.specification_type = specification_type;
         self.layers
             .iter_mut()
-            .map(|l| l.specification_type = specification_type)
-            .count();
+            .for_each(|l| l.specification_type = specification_type);
         self
     }
 
@@ -100,5 +100,54 @@ impl Manifest {
             size: compressed_size.0 as u64,
             digest: format!("sha256:{}", compressed_sha_v),
         });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn blob(blob_reference_type: BlobReferenceType) -> BlobReference {
+        BlobReference {
+            blob_reference_type,
+            specification_type: SpecificationType::Docker,
+            size: 1,
+            digest: "sha256:0".to_string(),
+        }
+    }
+
+    // A manifest assembled from a Docker (v2s2) base image, carrying a gzip and a zstd layer.
+    fn docker_base_manifest() -> Manifest {
+        Manifest {
+            schema_version: 2,
+            name: None,
+            specification_type: SpecificationType::Docker,
+            config: blob(BlobReferenceType::Config),
+            layers: vec![
+                blob(BlobReferenceType::LayerGz),
+                blob(BlobReferenceType::LayerZstd),
+            ],
+        }
+    }
+
+    // Regression: set_specification_type must retype the manifest envelope too, not just the
+    // config and layers. Leaving self.specification_type unchanged produced a Docker v2s2 envelope
+    // wrapping OCI config/layers (incl. tar+zstd) -- a non-conformant image rejected by skopeo,
+    // docker, and podman.
+    #[test]
+    fn set_specification_type_retypes_envelope_config_and_layers() {
+        let manifest = docker_base_manifest().set_specification_type(SpecificationType::Oci);
+
+        assert_eq!(manifest.specification_type, SpecificationType::Oci);
+        assert_eq!(manifest.config.specification_type, SpecificationType::Oci);
+        for layer in &manifest.layers {
+            assert_eq!(layer.specification_type, SpecificationType::Oci);
+        }
+
+        let serialized = String::from_utf8(manifest.to_bytes().unwrap()).unwrap();
+        assert!(serialized.contains("application/vnd.oci.image.manifest.v1+json"));
+        assert!(!serialized.contains("application/vnd.docker.distribution.manifest.v2+json"));
+        // Round-trips cleanly: the parsed envelope type matches the retyped config/layers.
+        assert_eq!(Manifest::parse_str(&serialized).unwrap(), manifest);
     }
 }


### PR DESCRIPTION
set_specification_type retyped the config and each layer but not the manifest's own specification_type. Since the serialized top-level mediaType derives from it, requesting OCI left the envelope as the base image's docker v2s2 while config/layers became OCI -- a non-conformant image: a docker v2s2 manifest referencing OCI layer media types (application/vnd.oci.image.layer.v1.tar+gzip and +zstd).

Strict OCI/distribution-spec tooling built on containers-image (skopeo, podman, buildah) rejects this with "unsupported docker v2s2 media type"; the docker CLI is lenient and accepts it.

Spec: https://github.com/opencontainers/image-spec/blob/main/media-types.md